### PR TITLE
learn --no-create-home option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,15 @@ based on [Keep a Changelog].
 
 autouseradd adheres to [Semantic Versioning].
 
+## [Unreleased]
+
+Learn to skip creating a home directory when the `--no-create-home` option, or
+its short form, `-M`, is specified.
+
 ## 1.0.0 / 2017-11-07
 
 Initial release.
 
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 [Semantic Versioning]: http://semver.org/spec/v2.0.0.html
+[Unreleased]: https://github.com/benesch/autouseradd/compare/v1.0.0...HEAD

--- a/test.bats
+++ b/test.bats
@@ -51,10 +51,28 @@ container() {
   [[ "$output" = "/home/auto" ]]
 }
 
+@test "--no-create-home" {
+  run container -u 501:502 autouseradd --no-create-home ls -l /home
+  [[ "$status" -eq 0 ]]
+  [[ "$output" = "total 0" ]]
+}
+
 @test "home directory permissions" {
   run container -u 501:502 autouseradd sh -c 'stat -c "%A %n" $HOME'
   [[ "$status" -eq 0 ]]
   [[ "$output" = "drwxr-xr-x /home/auto" ]]
+}
+
+@test "home directory exists" {
+  run container --volume=foo:/home/auto -u 501:502 autouseradd true
+  [[ "$status" -eq 0 ]]
+  [[ "$output" = *"warning: the home directory already exists"* ]]
+}
+
+@test "home directory exists with --no-create-home" {
+  run container --volume=foo:/home/auto -u 501:502 autouseradd --no-create-home true
+  [[ "$status" -eq 0 ]]
+  [[ -z "$output" ]]
 }
 
 @test "duplicate gid" {


### PR DESCRIPTION
useradd will print an annoying warning if the home directory exists and
--create-home is specified. Expose a --no-create-home option so that a
user can suppress the warning when it knows the home directory already
exists.