### PR TITLE
propagate TMPDIR and other secure-mode env vars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+autouseradd
+autouseradd-suid

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ based on [Keep a Changelog].
 
 autouseradd adheres to [Semantic Versioning].
 
+## Unreleased
+
+* Preserve environment variables that the glibc loader automatically strips from
+  the environment when executing a setuid binary like autouseradd. The most
+  notable such environment variable is `TMPDIR`. As a side effect, autouseradd
+  learned a new option, `-e NAME=VALUE`, which sets the environment variable
+  `NAME` to `VALUE`.
+
+  For more details about the environment variables stripped by the loader,
+  see the references to "secure-execution mode" in the [ld.so man page][ld.so].
+
+  [ld.so]: https://man7.org/linux/man-pages/man8/ld.so.8.html
+
+* Learn to print help when the `--help` option, or its short form `-h`, is
+  specified.
+
 ## [1.1.0] / 2018-07-31
 
 Learn to skip creating a home directory when the `--no-create-home` option, or

--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,20 @@
 PREFIX ?= /usr/local
 BINDIR = $(DESTDIR)$(PREFIX)/bin
+LIBEXECDIR = $(DESTDIR)$(PREFIX)/libexec
 MANDIR = $(DESTDIR)$(PREFIX)/share/man
 
-CFLAGS += -Wall -Wextra -Werror -O2
+CFLAGS += -Wall -Wextra -Werror -O2 -DPREFIX=$(PREFIX)
 
-all: autouseradd
+all: autouseradd autouseradd-suid
 
-install: autouseradd
-	install -d $(BINDIR) $(MANDIR)/man1
-	install -o root -g root -m u=rwxs,g=rxs,o=rx $< $(BINDIR)/$<
+install: autouseradd autouseradd-suid
+	install -d $(BINDIR) $(LIBEXECDIR) $(MANDIR)/man1
+	install -o root -g root -m u=rwx,g=rx,o=rx autouseradd $(BINDIR)/autouseradd
+	install -o root -g root -m u=rwxs,g=rxs,o=rx autouseradd-suid $(LIBEXECDIR)/autouseradd-suid
 	install -m u=rw,g=r,o=r autouseradd.1 $(MANDIR)/man1/autouseradd.1
 
 check:
 	docker build -f test-container.docker -t autouseradd .
-	bats test.bats
+	bats test.bats $(CHECKARGS)
 
 .PHONY: all install check

--- a/autouseradd-suid.c
+++ b/autouseradd-suid.c
@@ -1,0 +1,158 @@
+#define _GNU_SOURCE
+
+#include <err.h>
+#include <getopt.h>
+#include <pwd.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+const char* version = "1.1.0";
+
+const uid_t root_uid = 0;
+const gid_t root_gid = 0;
+
+const struct option long_options[] = {
+  {"user",           required_argument, 0, 'u'},
+  {"group",          required_argument, 0, 'g'},
+  {"shell",          required_argument, 0, 's'},
+  {"cwd",            required_argument, 0, 'C'},
+  {"env",            required_argument, 0, 'e'},
+  {"no-create-home", no_argument,       0, 'M'},
+  {"help",           no_argument,       0, 'h'},
+  {"version",        no_argument,       0, 'v'},
+  {0, 0, 0, 0}
+};
+
+void run(char* args[]) {
+  pid_t r;
+  if ((r = fork()) == 0) {
+    execv(args[0], args);
+    err(1, "exec");
+  } else if (r == -1)
+    err(1, "fork");
+  int wstatus;
+  if (waitpid(r, &wstatus, 0) == -1)
+    err(1, "waitpid");
+  if (!WIFEXITED(wstatus) || WEXITSTATUS(wstatus) != EXIT_SUCCESS)
+    errx(1, "%s failed", args[0]);
+}
+
+char* itoa(int id) {
+  char* s;
+  if (asprintf(&s, "%d", id) == -1)
+    err(1, "asprintf");
+  return s;
+}
+
+void usage(void) {
+  printf("synopsis: autouseradd [-u NAME] [-g NAME] [COMMAND [ARGS]]\n"
+    "\n"
+    "autouseradd adds a user and group named after that user to the system,\n"
+    "then invokes a command as that user.\n"
+    "\n"
+    "Options:\n"
+    "  -u, --user NAME       use NAME as the username for the created user\n"
+    "  -g, --group NAME      use NAME as the group name for the created user\n"
+    "  -s, --shell PATH      use PATH as the user's login shell\n"
+    "  -c, --cwd PATH        set the working directory to PATH\n"
+    "  -e, --env NAME=VALUE  set the environment variable NAME to VALUE\n"
+    "  --no-create-home      do not attempt to create a home directory for the user\n"
+    "  --help                print this help and exit\n"
+    "  --version             print the version and exit\n"
+    "\n"
+    "See the man page for a more complete description.\n");
+}
+
+int main(int argc, char* argv[]) {
+  char* user = "auto";
+  char* group = NULL;
+  char* shell = "/bin/bash";
+  int envc = 0;
+  char* envs[argc];
+  char* cwd = NULL;
+  bool create_home = true;
+
+  int c;
+  while ((c = getopt_long(argc, argv, "+u:g:s:C:e:hv", long_options, NULL)) != -1) {
+    switch (c) {
+      case 'u':
+        user = optarg;
+        break;
+      case 'g':
+        group = optarg;
+        break;
+      case 's':
+        shell = optarg;
+        break;
+      case 'C':
+        cwd = optarg;
+        break;
+      case 'e':
+        envs[envc++] = optarg;
+        break;
+      case 'M':
+        create_home = false;
+        break;
+      case 'h':
+        usage();
+        exit(0);
+      case 'v':
+        printf("autouseradd %s\n", version);
+        exit(0);
+      case '?':
+        exit(1);
+      default:
+        errx(1, "option parsing failed");
+      }
+  }
+  if (group == NULL)
+    group = user;
+
+  uid_t ruid, euid, suid, rgid, egid, sgid;
+  if (getresuid(&ruid, &euid, &suid) != 0)
+    err(1, "getresuid");
+  if (getresgid(&rgid, &egid, &sgid) != 0)
+    err(1, "getresgid");
+  if (ruid == root_uid || rgid == root_gid)
+    errx(1, "running as root is not permitted");
+  if (euid != root_uid)
+    errx(1, "setuid bit not set: %d", euid);
+
+  char* ruids = itoa(ruid);
+  char* rgids = itoa(rgid);
+  run((char* []){"/usr/sbin/groupadd", "--gid", rgids, group, NULL});
+  run((char* []){"/usr/sbin/useradd", "--no-user-group",
+    create_home ? "--create-home" : "--no-create-home",
+    "--uid", ruids, "--gid", rgids, "--shell", shell, user, NULL});
+  free(ruids);
+  free(rgids);
+
+  struct passwd* pwent = getpwuid(ruid);
+  if (pwent == NULL)
+    err(1, "getpwuid");
+  if (pwent->pw_dir == NULL || strlen(pwent->pw_dir) == 0)
+    errx(1, "user created without home directory");
+  setenv("HOME", pwent->pw_dir, 1 /* overwrite */);
+
+  if (setresuid(ruid, ruid, ruid) == -1)
+    err(1, "setresuid");
+  if (setresgid(rgid, rgid, rgid) == -1)
+    err(1, "setresgid");
+
+  if (cwd != NULL && chdir(cwd) == -1)
+    err(1, "chdir");
+
+  for (int i = 0; i < envc; i++)
+    putenv(envs[i]);
+
+  if (argc == optind)
+    execl(shell, shell, (char*) NULL);
+  else
+    execvp(argv[optind], &argv[optind]);
+  err(1, "exec");
+}

--- a/autouseradd.1
+++ b/autouseradd.1
@@ -18,19 +18,36 @@ the same name or ID already exists.
 The following options are available:
 .TP 4
 \fB\-u\fR \fIname\fR, \fB\-\-user\fR=\fIname\fR
-Use \fIname\fR as the username for the created user. If this option is not
+Use \fIname\fR as the name for the created user. If this option is not
 specified, the username defaults to \fIauto\fR.
 .TP 4
 \fB\-g\fR \fIname\fR, \fB\-\-group\fR=\fIname\fR
-Use \fIname\fR as the username for the created group. If this option is not
+Use \fIname\fR as the name for the created group. If this option is not
 specified, the group name defaults to the user name.
 .TP 4
 \fB\-s\fR \fIpath\fR, \fB\-\-shell\fR=\fIpath\fR
 Set the user's login shell to \fIpath\fR. If this option is not specified, the
 shell defaults to \fB/bin/bash\fR.
 .TP 4
+\fB\-c\fR \fIpath\fR, \fB\-\-cwd\fR=\fIpath\fR
+Set the working directory to \fIpath\fR before executing \fIcommand\fR. If this
+option is not specified, the current working directory is preserved.
+.TP 4
+\fB\-e\fR \fIname\fR[=\fIvalue\fR], \fB\-\-env\fR=\fIname\fR[=\fIvalue\fR]
+Set the environment variable \fIname\fR to \fIvalue\fR before executing
+\fIcommand\fR. If the equals sign and \fIvalue\fR are omitted, then \fIname\fR is
+unset. If multiple \fB\-e\fR options mention the same environment variable, the
+last option takes precedence. If no \fB\-e\fR option mentions a given
+environment variable, its current value is preserved.
+.TP 4
 \fB\-M\fR, \fB\-\-no-create-home\fR
 Don't attempt to create a home directory for the user.
+.TP 4
+\fB\-h\fR, \fB\-\-help\fR
+Print usage and exit.
+.TP 4
+\fB\-v\fR, \fB\-\-version\fR
+Print the version and exit.
 .
 .SH "EXIT STATUS"
 \fBautouseradd\fR exits with a value of 1 if an error occurs, otherwise it exits

--- a/test-container.docker
+++ b/test-container.docker
@@ -3,7 +3,7 @@ FROM ubuntu:xenial-20171006
 RUN apt-get update \
  && apt-get install --yes make gcc
 
-COPY Makefile autouseradd.c autouseradd.1 /build/
+COPY Makefile autouseradd.c autouseradd-suid.c autouseradd.1 /build/
 
 RUN cd /build \
  && make install \

--- a/test.bats
+++ b/test.bats
@@ -75,6 +75,36 @@ container() {
   [[ -z "$output" ]]
 }
 
+@test "env propagates" {
+  run container -u 501:502 -e FOO=bar autouseradd sh -c 'echo $FOO'
+  [[ "$status" -eq 0 ]]
+  [[ "$output" = "bar" ]]
+}
+
+@test "env overrides" {
+  run container -u 501:502 -e FOO=outside autouseradd -e FOO=inside1 -e FOO=inside2 sh -c 'echo $FOO'
+  [[ "$status" -eq 0 ]]
+  [[ "$output" = "inside2" ]]
+}
+
+@test "env unset" {
+  run container -u 501:502 -e FOO=outside autouseradd -e FOO sh -uc 'echo $FOO'
+  [[ "$status" -eq 2 ]]
+  [[ "$output" = "sh: 1: FOO: parameter not set" ]]
+}
+
+@test "tmpdir propagates" {
+  run container -u 501:502 -e TMPDIR=/foo autouseradd sh -c 'echo $TMPDIR'
+  [[ "$status" -eq 0 ]]
+  [[ "$output" = "/foo" ]]
+}
+
+@test "tmpdir overrides" {
+  run container -u 501:502 -e TMPDIR=/outside autouseradd -e TMPDIR=/inside sh -c 'echo $TMPDIR'
+  [[ "$status" -eq 0 ]]
+  [[ "$output" = "/inside" ]]
+}
+
 @test "duplicate gid" {
   run container -u 501:1 autouseradd
   [[ "$status" -eq 1 ]]


### PR DESCRIPTION
The glibc loader will automatically strip some environment variables
when executing a setuid binary. Manually propagate these variables
through to the executed command.

Also, update the man page, which was a bit out of date,  and learn the
`--help` option.

Details in the changelog.